### PR TITLE
Fix pylint issues

### DIFF
--- a/adafruit_binascii.py
+++ b/adafruit_binascii.py
@@ -146,7 +146,7 @@ def a2b_base64(b64_data: ReadableBuffer) -> bytes:
             last_char_was_a_pad = False
     else:
         if leftbits != 0:
-            raise Exception("Incorrect padding")
+            raise ValueError("Incorrect padding")
 
     return b"".join(res)
 

--- a/examples/binascii_simpletest.py
+++ b/examples/binascii_simpletest.py
@@ -13,7 +13,7 @@ hex_data = hexlify(data)
 print("Hex Data: ", hex_data)
 # Verify data
 assert (
-    hex_data == b"43697263756974507974686f6e20697320417765736f6d6521",
+    hex_data == b"43697263756974507974686f6e20697320417765736f6d6521"
 ), "hexlified data does not match expected data."
 # Get the binary data represented by hex_data
 bin_data = unhexlify(hex_data)


### PR DESCRIPTION
Outgoing exception changed to `ValueError` (best guess but there might be a more suitable error) - a major revision update should be considered.